### PR TITLE
Pin vpc module version

### DIFF
--- a/aws-vpc/main.tf
+++ b/aws-vpc/main.tf
@@ -11,7 +11,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
+  version = "~> 5.18.0"
 
   name = var.vpc_name
   cidr = var.vpc_cidr


### PR DESCRIPTION
`aws_vpc_public_access_block_x` resources causing errors even with provider version that should support them.

Errors:
- The provider hashicorp/aws does not support resource type "aws_vpc_block_public_access_options".
- The provider hashicorp/aws does not support resource type "aws_vpc_block_public_access_exclusion".