### PR TITLE
Pin k8s addons module version

### DIFF
--- a/aws-eks-addon/main.tf
+++ b/aws-eks-addon/main.tf
@@ -6,7 +6,7 @@ locals {
 
 module "eks_blueprints_addons" {
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "~> 1.1"
+  version = "1.18.0"
 
   cluster_name          = var.cluster_name
   cluster_endpoint      = var.cluster_endpoint


### PR DESCRIPTION
Pin module version to before requirement for random provider.

Error:
- The root module for component.k8s-addons requires a provider configuration named "random" for provider "hashicorp/random", which is not assigned in the block's "providers" argument.